### PR TITLE
next.config.tsからnext.config.jsに変更

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
+const nextConfig = {
   /* config options here */
   transpilePackages: ["jotai-devtools"],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "src/guest"
+    "src/guest",
+    "next.config.js"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
vercelにデプロイした後、lpからtopにページ遷移がうまくいかない。原因としては、next.config.tsがtypescriptになっていることが原因として挙げられるのでjsに変換
